### PR TITLE
feat: update lambda runtime to nodejs v16

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -65,12 +65,12 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 5,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D622e311034dd41647e4fe9b3802c5f55c3": Object {
+    "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D627dbec5a8502ab12d36dafcbdebcc9fd6": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "AuthLambdasCheckAuthFunction6B3C9473",
@@ -90,7 +90,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-CheckAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D622e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D627dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-CheckAuthFunction-function-arn\\"}}",
             ],
@@ -110,7 +110,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-CheckAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D622e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasCheckAuthFunctionCurrentVersionF10C4D627dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-CheckAuthFunction-function-arn\\"}}",
             ],
@@ -159,12 +159,12 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 5,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E2e311034dd41647e4fe9b3802c5f55c3": Object {
+    "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E7dbec5a8502ab12d36dafcbdebcc9fd6": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "AuthLambdasHttpHeadersFunctionC7A2BAB9",
@@ -184,7 +184,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-HttpHeadersFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E2e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E7dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-HttpHeadersFunction-function-arn\\"}}",
             ],
@@ -204,7 +204,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-HttpHeadersFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E2e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasHttpHeadersFunctionCurrentVersion8B8CDE2E7dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-HttpHeadersFunction-function-arn\\"}}",
             ],
@@ -253,12 +253,12 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 5,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthLambdasParseAuthFunctionCurrentVersionA32A59912e311034dd41647e4fe9b3802c5f55c3": Object {
+    "AuthLambdasParseAuthFunctionCurrentVersionA32A59917dbec5a8502ab12d36dafcbdebcc9fd6": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "AuthLambdasParseAuthFunctionC04A121B",
@@ -278,7 +278,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-ParseAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasParseAuthFunctionCurrentVersionA32A59912e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasParseAuthFunctionCurrentVersionA32A59917dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-ParseAuthFunction-function-arn\\"}}",
             ],
@@ -298,7 +298,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-ParseAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasParseAuthFunctionCurrentVersionA32A59912e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasParseAuthFunctionCurrentVersionA32A59917dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-ParseAuthFunction-function-arn\\"}}",
             ],
@@ -347,12 +347,12 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 5,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthLambdasRefreshAuthFunctionCurrentVersion632285F62e311034dd41647e4fe9b3802c5f55c3": Object {
+    "AuthLambdasRefreshAuthFunctionCurrentVersion632285F67dbec5a8502ab12d36dafcbdebcc9fd6": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "AuthLambdasRefreshAuthFunction4B0B3BD6",
@@ -372,7 +372,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-RefreshAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasRefreshAuthFunctionCurrentVersion632285F62e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasRefreshAuthFunctionCurrentVersion632285F67dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-RefreshAuthFunction-function-arn\\"}}",
             ],
@@ -392,7 +392,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-RefreshAuthFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasRefreshAuthFunctionCurrentVersion632285F62e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasRefreshAuthFunctionCurrentVersion632285F67dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-RefreshAuthFunction-function-arn\\"}}",
             ],
@@ -479,12 +479,12 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 5,
       },
       "Type": "AWS::Lambda::Function",
     },
-    "AuthLambdasSignOutFunctionCurrentVersion0576BBB12e311034dd41647e4fe9b3802c5f55c3": Object {
+    "AuthLambdasSignOutFunctionCurrentVersion0576BBB17dbec5a8502ab12d36dafcbdebcc9fd6": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "AuthLambdasSignOutFunction251863E4",
@@ -504,7 +504,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-SignOutFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasSignOutFunctionCurrentVersion0576BBB12e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasSignOutFunctionCurrentVersion0576BBB17dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-SignOutFunction-function-arn\\"}}",
             ],
@@ -524,7 +524,7 @@ Object {
             Array [
               "{\\"service\\":\\"SSM\\",\\"action\\":\\"putParameter\\",\\"parameters\\":{\\"Name\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-SignOutFunction-function-arn\\",\\"Value\\":\\"",
               Object {
-                "Ref": "AuthLambdasSignOutFunctionCurrentVersion0576BBB12e311034dd41647e4fe9b3802c5f55c3",
+                "Ref": "AuthLambdasSignOutFunctionCurrentVersion0576BBB17dbec5a8502ab12d36dafcbdebcc9fd6",
               },
               "\\",\\"Type\\":\\"String\\",\\"Overwrite\\":true},\\"region\\":\\"eu-west-1\\",\\"physicalResourceId\\":{\\"id\\":\\"/cf/region/us-east-1/stack/Stack1/c822e4a2b5e248e64ee706fb7d4af8c80d9b03944e-SignOutFunction-function-arn\\"}}",
             ],
@@ -1401,7 +1401,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/src/generate-secret.ts
+++ b/src/generate-secret.ts
@@ -56,7 +56,7 @@ class GenerateSecretProvider extends Construct {
           path.join(__dirname, "../dist/generate-secret"),
         ),
         handler: "index.handler",
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_16_X,
       }),
     })
 

--- a/src/lambdas.ts
+++ b/src/lambdas.ts
@@ -85,7 +85,7 @@ export class AuthLambdas extends Construct {
           ? lambda.Code.fromInline("snapshot-value")
           : lambda.Code.fromAsset(path.join(__dirname, `../dist/${assetName}`)),
       handler: "index.handler",
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       timeout: Duration.seconds(5),
       role,
       description:


### PR DESCRIPTION
AWS is ending support for the Node.js 12 runtime starting 14. Nov this year.

The changes introduced in 12 -> 14 [1] and 14 -> 16 [2] should not have an effect on most Node.js projects. At a glance, I can't see anything that would break the Lambdas configured in this construct.

[1]: https://nodejs.org/en/blog/release/v14.0.0/
[2]: https://nodejs.org/en/blog/release/v16.0.0/