### PR TITLE
feat: allow overriding http headers

### DIFF
--- a/src/cloudfront-auth.ts
+++ b/src/cloudfront-auth.ts
@@ -66,6 +66,12 @@ export interface CloudFrontAuthProps {
    * access any resource.
    */
   requireGroupAnyOf?: string[]
+  /**
+   * HTTP headers to be added to all CloudFront responses.
+   *
+   * @example { "Referrer-Policy": "same-origin" }
+   */
+  httpHeaders?: Record<string, string>
 }
 
 export interface UpdateClientProps {
@@ -161,6 +167,7 @@ export class CloudFrontAuth extends Construct {
         "X-Frame-Options": "DENY",
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "no-cache",
+        ...(props.httpHeaders ?? {}),
       },
       logLevel: props.logLevel ?? "warn",
       userPoolId: this.userPool.userPoolId,


### PR DESCRIPTION
While integrating this repository I came across an CSP error trying to create a service worker:

`Failed to construct 'Worker': Access to the script at 'blob:https://foo.bar/f857a673-313d-42d9-965b-bfc803440b1e' is denied by the document's Content Security Policy.`

I couldn't really find a way to override the headers, so here I am with the pull request!

Let me know if you want anything changed.